### PR TITLE
Removed redundant rule from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 node-modules/
 elm-stuff/
 elm.js
-!elm-package.json


### PR DESCRIPTION
The removed line is redundant since there is no pattern that would match the `elm-package.json` file name.